### PR TITLE
Peristaltic pumps

### DIFF
--- a/science_jubilee/decks/Deck.py
+++ b/science_jubilee/decks/Deck.py
@@ -41,7 +41,7 @@ class Deck(SlotSet):
         self.deck_config = deck_config
         self.slots_data = self.deck_config.get('slots', {})
         self.slots = self._get_slots()
-        self._safe_z = None
+        self._safe_z = 10
     
     def _get_slots(self):
         slots = {}

--- a/science_jubilee/tools/PeristalticPumps.py
+++ b/science_jubilee/tools/PeristalticPumps.py
@@ -1,0 +1,26 @@
+import json
+import logging
+import os
+
+from science_jubilee.tools.Tool import Tool, ToolStateError, ToolConfigurationError, requires_active_tool
+from typing import Tuple, Union
+
+
+
+class PeristalticPump(Tool):
+    """
+    Class to manage peristaltic pump operation
+    """
+
+    def init():
+
+        # load config file
+
+        # check if mm to volume conversion has been calibrated by user
+
+    def pump(volume:float, speed: float):
+        """turn on pump to dispense volume at speed"""
+
+        # calculate 'mm' to dispense given volume
+        
+        # dispense given volume

--- a/science_jubilee/tools/PeristalticPumps.py
+++ b/science_jubilee/tools/PeristalticPumps.py
@@ -12,15 +12,48 @@ class PeristalticPump(Tool):
     Class to manage peristaltic pump operation
     """
 
-    def init():
+    def __init__(self, index, steps_per_ml, ):
 
         # load config file
 
         # check if mm to volume conversion has been calibrated by user
+        # overwrite machine steps per mm with config supplied one
+        # send M92E{value}
+
+       
+
+    @classmethod
+    def from_config(cls, machine, index, name, config_file: str,
+                    path :str = os.path.join(os.path.dirname(__file__), 'configs')):
+        
+        """Initialize the pipette object from a config file
+
+        :param machine: The :class:`Machine` object that the pipette is loaded on
+        :type machine: :class:`Machine`
+        :param index: The tool index of the pipette on the machine
+        :type index: int
+        :param name: The tool name
+        :type name: str
+        :param config_file: The name of the config file containign the pipette parameters
+        :type config_file: str
+        :returns: A :class:`Pipette` object
+        :rtype: :class:`Pipette`
+        """        
+        config = os.path.join(path,config_file)
+        with open(config) as f:
+            kwargs = json.load(f)
+
+        return cls(machine, index, name, **kwargs)
 
     def pump(volume:float, speed: float):
         """turn on pump to dispense volume at speed"""
 
         # calculate 'mm' to dispense given volume
+        # actually this is handled in the steps to mm conversion programmed in axis setup on Jubilee 
         
         # dispense given volume
+        volumes = [0,0,0]
+        volumes[pippette_index] = volume
+        stringvol = ':'.join([str(v) for v in volumes]) # negative b/c gcode pump reverse is suspect for now
+
+        self.gcode(f'G1 E{stringvol}')

--- a/science_jubilee/tools/PeristalticPumps.py
+++ b/science_jubilee/tools/PeristalticPumps.py
@@ -5,35 +5,26 @@ import os
 from science_jubilee.tools.Tool import Tool, ToolStateError, ToolConfigurationError, requires_active_tool
 from typing import Tuple, Union
 
+class PeristalticPumpIndividual(Tool):
 
+    """Class representation for an individual peristaltic pump. Individual pumps should be combined into a pumps group to work correctly 
+    
+    
+    Really the only reason to have this as its own class is to let you use pumps with different steps per mm"""
 
-class PeristalticPump(Tool):
-    """
-    Class to manage peristaltic pump operation
-    """
+    def __init__(self, steps_per_ml: float, name: str, user_calibrated: bool = False):
 
-    def __init__(self, index, steps_per_ml, ):
+        super().__init__(steps_per_ml = steps_per_ml, name = name, user_calibrated = user_calibrated)
 
-        # load config file
-
-        # check if mm to volume conversion has been calibrated by user
-        # overwrite machine steps per mm with config supplied one
-        # send M92E{value}
-
-       
+        if not user_calibrated:
+            raise Warning('Peristaltic pump not calibrated, accuracy may be inadequate')       
 
     @classmethod
-    def from_config(cls, machine, index, name, config_file: str,
+    def from_config(cls, config_file: str,
                     path :str = os.path.join(os.path.dirname(__file__), 'configs')):
         
         """Initialize the pipette object from a config file
 
-        :param machine: The :class:`Machine` object that the pipette is loaded on
-        :type machine: :class:`Machine`
-        :param index: The tool index of the pipette on the machine
-        :type index: int
-        :param name: The tool name
-        :type name: str
         :param config_file: The name of the config file containign the pipette parameters
         :type config_file: str
         :returns: A :class:`Pipette` object
@@ -43,17 +34,58 @@ class PeristalticPump(Tool):
         with open(config) as f:
             kwargs = json.load(f)
 
-        return cls(machine, index, name, **kwargs)
+        return cls(**kwargs)
 
-    def pump(volume:float, speed: float):
+class PeristalticPumps(Tool):
+    """
+    A class representation of a group of PeristalticPumpIndividual objects. Can instantiate with list of PeristalticPumpIndividual objects or a number of pumps to generate and a config. Generic to any stepper-driven peristaltic pump. Combine with PumpDispenser tool for bulk low-precision liquid handling.
+    """
+
+    def __init__(self, index, pumps = None, n_pumps = None, steps_per_ml = None, config_file = None, tool_axis = 'E'):
+
+        self.index = index
+        
+        if pumps is not None:
+            assert isinstance(pumps, list), '"pumps" must be a list of PeristalticPumpIndividual objects'
+            self.pumps = pumps
+
+        elif n_pumps is not None:
+            assert isinstance(n_pumps, int), '"n_pumps" must be an int'
+            if config_file is not None:
+                pump = PeristalticPumpIndividual.from_config(config_file)
+            elif steps_per_ml is not None:
+                pump = PeristalticPumpIndividual(steps_per_ml, 'generic_pump', user_calibrated=True)
+            self.pumps = [pump]*n_pumps
+
+        self.n_pumps = len(self.pumps)
+
+    def post_load(self):
+        """
+        After tool load, set steps per mm on machine
+        """
+        #set steps per mL on machine
+        steps_per_ml = [str(pump.steps_per_mm) for pump in self.pumps]
+
+        gcode = f"M92 {self.tool_axis}"+':'.join(str(steps_per_ml))
+        self._machine.gcode(gcode)
+
+        return
+
+    @requires_active_tool
+    def pump(self, volume: [float, list], speed: float):
         """turn on pump to dispense volume at speed"""
 
         # calculate 'mm' to dispense given volume
         # actually this is handled in the steps to mm conversion programmed in axis setup on Jubilee 
         
         # dispense given volume
-        volumes = [0,0,0]
-        volumes[pippette_index] = volume
-        stringvol = ':'.join([str(v) for v in volumes]) # negative b/c gcode pump reverse is suspect for now
+        if isinstance(volume, list):
+            pass
 
-        self.gcode(f'G1 E{stringvol}')
+        elif isinstance(volume, float):
+            volume = [volume]*self.n_pumps
+
+        stringvol = ':'.join([str(v) for v in volume]) # negative b/c gcode pump reverse is suspect for now
+
+        # sticking with a direct gcode to send here makes sense: no 3-motor on axis support in movement code, and no risk of crashing anything here
+        self.gcode(f'G1 {self.tool_axis}{stringvol}')

--- a/science_jubilee/tools/PeristalticPumps.py
+++ b/science_jubilee/tools/PeristalticPumps.py
@@ -5,19 +5,23 @@ import os
 from science_jubilee.tools.Tool import Tool, ToolStateError, ToolConfigurationError, requires_active_tool
 from typing import Tuple, Union
 
-class PeristalticPumpIndividual(Tool):
+class PeristalticPumps(Tool):
+    """
+    A class representation of a group of PeristalticPumpIndividual objects. Can instantiate with number of pumps to generate and a config. Generic to any stepper-driven peristaltic pump. Combine with PumpDispenser tool for bulk low-precision liquid handling.
+    """
 
-    """Class representation for an individual peristaltic pump. Individual pumps should be combined into a pumps group to work correctly 
-    
-    
-    Really the only reason to have this as its own class is to let you use pumps with different steps per mm"""
+    def __init__(self, index: int, n_pumps: int, steps_per_ml: Union[float, list], tool_axis: str = 'E', name: str = 'dispenser_pumps'):
 
-    def __init__(self, steps_per_ml: float, name: str, user_calibrated: bool = False):
+        self.index = index
+        self.tool_axis = tool_axis
+        self.n_pumps = n_pumps
+        self.name = name
 
-        super().__init__(steps_per_ml = steps_per_ml, name = name, user_calibrated = user_calibrated)
-
-        if not user_calibrated:
-            raise Warning('Peristaltic pump not calibrated, accuracy may be inadequate')       
+        if isinstance(steps_per_ml, float) or isinstance(steps_per_ml, int):
+            self.steps_per_ml = [steps_per_ml]*n_pumps
+        elif isinstance(steps_per_ml, list):
+            assert len(steps_per_ml) == n_pumps, 'steps per ml list length much equal number of pumps'
+            self.steps_per_ml = steps_per_ml
 
     @classmethod
     def from_config(cls, config_file: str,
@@ -25,6 +29,12 @@ class PeristalticPumpIndividual(Tool):
         
         """Initialize the pipette object from a config file
 
+        :param machine: The :class:`Machine` object that the pipette is loaded on
+        :type machine: :class:`Machine`
+        :param index: The tool index of the pipette on the machine
+        :type index: int
+        :param name: The tool name
+        :type name: str
         :param config_file: The name of the config file containign the pipette parameters
         :type config_file: str
         :returns: A :class:`Pipette` object
@@ -33,59 +43,42 @@ class PeristalticPumpIndividual(Tool):
         config = os.path.join(path,config_file)
         with open(config) as f:
             kwargs = json.load(f)
-
+        print(kwargs)
         return cls(**kwargs)
-
-class PeristalticPumps(Tool):
-    """
-    A class representation of a group of PeristalticPumpIndividual objects. Can instantiate with list of PeristalticPumpIndividual objects or a number of pumps to generate and a config. Generic to any stepper-driven peristaltic pump. Combine with PumpDispenser tool for bulk low-precision liquid handling.
-    """
-
-    def __init__(self, index, pumps = None, n_pumps = None, steps_per_ml = None, config_file = None, tool_axis = 'E'):
-
-        self.index = index
         
-        if pumps is not None:
-            assert isinstance(pumps, list), '"pumps" must be a list of PeristalticPumpIndividual objects'
-            self.pumps = pumps
-
-        elif n_pumps is not None:
-            assert isinstance(n_pumps, int), '"n_pumps" must be an int'
-            if config_file is not None:
-                pump = PeristalticPumpIndividual.from_config(config_file)
-            elif steps_per_ml is not None:
-                pump = PeristalticPumpIndividual(steps_per_ml, 'generic_pump', user_calibrated=True)
-            self.pumps = [pump]*n_pumps
-
-        self.n_pumps = len(self.pumps)
 
     def post_load(self):
         """
         After tool load, set steps per mm on machine
         """
         #set steps per mL on machine
-        steps_per_ml = [str(pump.steps_per_mm) for pump in self.pumps]
+        steps_per_ml = self.steps_per_ml
 
-        gcode = f"M92 {self.tool_axis}"+':'.join(str(steps_per_ml))
+        gcode = f"M92 {self.tool_axis}"+':'.join([str(stpml) for stpml in steps_per_ml])
+        print(gcode)
         self._machine.gcode(gcode)
 
         return
+    
 
-    @requires_active_tool
-    def pump(self, volume: [float, list], speed: float):
-        """turn on pump to dispense volume at speed"""
+    def pump(self, volume: Union[int, float, list]):
+        """turn on pump to dispense volume"""
 
         # calculate 'mm' to dispense given volume
         # actually this is handled in the steps to mm conversion programmed in axis setup on Jubilee 
         
         # dispense given volume
         if isinstance(volume, list):
+            assert isinstance(volume[0], float) or isinstance(volume[0], int), 'Volume list must be floats or ints'
             pass
 
-        elif isinstance(volume, float):
+        elif isinstance(volume, float) or isinstance(volume, int):
             volume = [volume]*self.n_pumps
+        
+        else:
+            raise TypeError('Volume must be an int, float, or list of ints or floats')
 
         stringvol = ':'.join([str(v) for v in volume]) # negative b/c gcode pump reverse is suspect for now
 
         # sticking with a direct gcode to send here makes sense: no 3-motor on axis support in movement code, and no risk of crashing anything here
-        self.gcode(f'G1 {self.tool_axis}{stringvol}')
+        self._machine.gcode(f'G1 {self.tool_axis}{stringvol}')

--- a/science_jubilee/tools/Pipette.py
+++ b/science_jubilee/tools/Pipette.py
@@ -4,6 +4,7 @@ import os
 
 from science_jubilee.labware.Labware import Labware, Well, Location
 from science_jubilee.tools.Tool import Tool, ToolStateError, ToolConfigurationError, requires_active_tool
+from science_jubilee import utils
 from typing import Tuple, Union
 
 
@@ -125,27 +126,6 @@ class Pipette(Tool):
 
         return cls(machine, index, name, **kwargs)
     
-    @staticmethod
-    def _getxyz(location: Union[Well, Tuple, Location]):
-        """Helper function to extract the x, y, z coordinates of a location object.
-
-        :param location: The location object to extract the coordinates from. This can either be a 
-            :class:`Well`, a :tuple: of x, y, z coordinates, or a :class:`Location` object
-        :type location: Union[Well, Tuple, Location]
-        :raises ValueError: If the location is not a :class:`Well`, a :class:`tuple`, or a :class:`Location` object
-        :return: The x, y, z coordinates of the location
-        :rtype: float, float, float
-        """
-        if type(location) == Well:
-            x, y, z = location.x, location.y, location.z
-        elif type(location) == Tuple:
-            x, y, z = location
-        elif type(location)==Location:
-            x,y,z= location._point
-        else:
-            raise ValueError("Location should be of type Well or Tuple")
-        
-        return x,y,z
            
     def vol2move(self, vol):
         """Converts desired volume in uL to a movement of the pipette motor axis
@@ -203,7 +183,7 @@ class Pipette(Tool):
         :type s: int, optional
         :raises ToolStateError: If the pipette does not have a tip attached
         """
-        x, y, z = self._getxyz(location)
+        x, y, z = self.utils.getxyz(location)
         
         if type(location) == Well:
             self.current_well = location
@@ -254,7 +234,7 @@ class Pipette(Tool):
 
         Note:: Ideally the user does not call this functions directly, but instead uses the :method:`dispense` method
         """
-        x, y, z = self._getxyz(location)
+        x, y, z = self.utils.getxyz(location)
         
         if type(location) == Well:
             self.current_well = location
@@ -305,7 +285,7 @@ class Pipette(Tool):
         
         vol_ = self.vol2move(vol)
         # get locations
-        xs, ys, zs = self._getxyz(source_well)
+        xs, ys, zs = self.utils.getxyz(source_well)
 
         if self.is_primed == True:
             pass
@@ -318,7 +298,7 @@ class Pipette(Tool):
 
         if isinstance(destination_well, list):
             for well in destination_well:
-                xd, yd, zd =self._getxyz(well)
+                xd, yd, zd =self.utils.getxyz(well)
             
                 self._machine.safe_z_movement()
                 self._machine.move_to(x= xs, y=ys)
@@ -519,7 +499,7 @@ class Pipette(Tool):
         else:
             tip = tip_
 
-        x, y, z = self._getxyz(tip)
+        x, y, z = self.utils.getxyz(tip)
         self._machine.safe_z_movement()
         self._machine.move_to(x=x, y=y)
         self._pickup_tip(z)
@@ -540,9 +520,9 @@ class Pipette(Tool):
         :type location: :class:`Well`, optional
         """
         if location is None:
-            x, y, z = self._getxyz(self.first_available_tip)
+            x, y, z = self.utils.getxyz(self.first_available_tip)
         else:
-            x, y, z = self._getxyz(location)
+            x, y, z = self.utils.getxyz(location)
         self._machine.safe_z_movement()
         self._machine.move_to(x=x, y=y)
         # z moves up/down to make sure tip actually makes it into rack 
@@ -577,7 +557,7 @@ class Pipette(Tool):
         :param location: The location to drop the tip into
         :type location: Union[:class:`Well`, tuple]
         """        
-        x, y, z = self._getxyz(location)
+        x, y, z = self.utils.getxyz(location)
 
         self._machine.safe_z_movement()
         if x is not None or y is not None:

--- a/science_jubilee/tools/Pipette.py
+++ b/science_jubilee/tools/Pipette.py
@@ -63,7 +63,7 @@ class Pipette(Tool):
     :type current_well: :class:`Well`
 
     """
-    def __init__(self, index, name, brand, model, max_volume,
+    def __init__(self, machine, index, name, brand, model, max_volume,
                   min_volume, zero_position, blowout_position, 
                   drop_tip_position, mm_to_ul):
         """ Initialize the pipette object
@@ -96,6 +96,7 @@ class Pipette(Tool):
                          model = model, max_volume = max_volume, min_volume = min_volume,
                          zero_position = zero_position, blowout_position = blowout_position,
                          drop_tip_position = drop_tip_position, mm_to_ul = mm_to_ul)
+        self._machine = machine
         self.has_tip = False
         # TODO: add a way to change this to True/False and check before performing action with tool
         self.first_available_tip = None
@@ -183,7 +184,7 @@ class Pipette(Tool):
         :type s: int, optional
         :raises ToolStateError: If the pipette does not have a tip attached
         """
-        x, y, z = self.utils.getxyz(location)
+        x, y, z = utils.getxyz(location)
         
         if type(location) == Well:
             self.current_well = location
@@ -234,7 +235,7 @@ class Pipette(Tool):
 
         Note:: Ideally the user does not call this functions directly, but instead uses the :method:`dispense` method
         """
-        x, y, z = self.utils.getxyz(location)
+        x, y, z = utils.getxyz(location)
         
         if type(location) == Well:
             self.current_well = location
@@ -285,7 +286,7 @@ class Pipette(Tool):
         
         vol_ = self.vol2move(vol)
         # get locations
-        xs, ys, zs = self.utils.getxyz(source_well)
+        xs, ys, zs = utils.getxyz(source_well)
 
         if self.is_primed == True:
             pass
@@ -298,7 +299,7 @@ class Pipette(Tool):
 
         if isinstance(destination_well, list):
             for well in destination_well:
-                xd, yd, zd =self.utils.getxyz(well)
+                xd, yd, zd = utils.getxyz(well)
             
                 self._machine.safe_z_movement()
                 self._machine.move_to(x= xs, y=ys)
@@ -499,7 +500,7 @@ class Pipette(Tool):
         else:
             tip = tip_
 
-        x, y, z = self.utils.getxyz(tip)
+        x, y, z = utils.getxyz(tip)
         self._machine.safe_z_movement()
         self._machine.move_to(x=x, y=y)
         self._pickup_tip(z)
@@ -520,9 +521,9 @@ class Pipette(Tool):
         :type location: :class:`Well`, optional
         """
         if location is None:
-            x, y, z = self.utils.getxyz(self.first_available_tip)
+            x, y, z = utils.getxyz(self.first_available_tip)
         else:
-            x, y, z = self.utils.getxyz(location)
+            x, y, z = utils.getxyz(location)
         self._machine.safe_z_movement()
         self._machine.move_to(x=x, y=y)
         # z moves up/down to make sure tip actually makes it into rack 
@@ -557,7 +558,7 @@ class Pipette(Tool):
         :param location: The location to drop the tip into
         :type location: Union[:class:`Well`, tuple]
         """        
-        x, y, z = self.utils.getxyz(location)
+        x, y, z = utils.getxyz(location)
 
         self._machine.safe_z_movement()
         if x is not None or y is not None:

--- a/science_jubilee/tools/PumpDispenser.py
+++ b/science_jubilee/tools/PumpDispenser.py
@@ -5,38 +5,117 @@ import os
 from science_jubilee.labware.Labware import Labware, Well, Location
 from science_jubilee.tools.Tool import Tool, ToolStateError, ToolConfigurationError, requires_active_tool
 from typing import Tuple, Union
+from science_jubilee import utils
 
 class PumpDispenser(Tool):
     """
     Class to manage dispenser tool, for example for a color mixing demo
     """
 
-    def init()
+
+    def __init__(self, index, pump_group, dispense_tip_offsets):
+        """
+        parameters for user to give:
+        - number of dispenser heads (only 3 supported for now)
+        - pump:dispenser head mapping
+        - garbage/waste well
+        - line prime/purge volume
+
+
+        This needs to have all the well management tooling of the pipette
+        """
+        super().__init__(index, pump_group = pump_group, dispense_tip_offsets = dispense_tip_offsets)
+
+        self.n_dispense_heads = len(self.dispense_tip_offsets)
+        self.waste = None
+        assert self.pump_group.n_pumps == self.n_dispense_heads, "Number of pumps must match number of dispenser tips"
+
+    def add_waste(self, location: Union[Well, Tuple, Location]):
+        """
+        Specify a waste collection container
+        """
+        assert isinstance(location, Union[Well, Tuple, Location]), 'location must be a well, tuple, or location'
+        self.waste = location
+
+
+    def dispense(self, vol: Union[float, int, list], location:Union[Well, Tuple, Location], dispense_head_index = None):
+        """
+        Dispense volume vol from dispense head dispense_head_index into location 
+        """
+        # get dispense volumes for each dispense head 
+        if isinstance(vol, list):
+            assert len(vol) == self.n_dispense_heads
+            dispense_volumes = vol
+        elif isinstance(vol, float) or isinstance(vol, int):
+            if dispense_head_index is None:
+                # dispense same volume from every head
+                dispense_volumes = [vol]*self.n_dispense_heads
+            elif isinstance(dispense_head_index, int):
+                volumes = [0]*self.n_dispense_heads
+                volumes[dispense_head_index] = vol
+            else:
+                raise AssertionError('dispense_head_index must be an integer') 
+        else:
+            raise AssertionError('vol must be a float, int, or list')
+
+
+        # calculate XY location for each dispense head
+        x, y, z = utils.getxyz(location)
+
+        if type(location) == Well:
+            if z == location.z:
+                z = z + 10
+            else:
+                pass
+        else:
+            pass
+
+        # iterate over each dispense head, skip if 0. Move to location and dispense 
+        for i, vol in enumerate(volumes):
+            if vol == 0:
+                continue
+            else:
+                tip_offsets = self.dispense_tip_offsets[i]
+                x_tip = x - tip_offsets[0]
+                y_tip = y - tip_offsets[1]
+
+                self._machine.safe_z_movement()
+                self._machine.move_to(x = x_tip, y = y_tip)
+                self._machine.move_to(z = z)
+
+                self.pump_group.pump(dispense_volumes)
+
         
-        # offsets live in config file, pipette tip '0' is centered in Jubilee duet-level setup
-        
-
-    """
-    parameters for user to give:
-    - number of dispenser heads (only 3 supported for now)
-    - pump:dispenser head mapping
-    - garbage/waste well
-    - line prime/purge volume
 
 
-    This needs to have all the well management tooling of the pipette
-    """
-
-    def dispense(well, volume, speed, dispense head):
-
-
-    def prime_lines(volume):
+    def prime_lines(self, volume: Union[int, float] = None, location:Union[Well, Tuple, Location] = None):
         """
         fill lines with liquid from all pumps at same time, dispense `volume` from each pump
         """
 
-    def empty_lines(volume):
+        if volume is None:
+            try:
+                volume = self.prime_line_volume
+            except AttributeError:
+                raise AssertionError('Line prime volume not specified in configuration. Please specify a volume')
+        
+        if location is None and self.waste is None:
+            raise AssertionError('Please specify a waste location')
+        
+        self.dispense(volume, location)
+
+        
+    def empty_lines(self, volume: Union[int, float] = None):
         """
         return line contents to stock wells
         """
+        if volume is None:
+            try:
+                volume = self.prime_line_volume
+            except AttributeError:
+                raise AssertionError('Line prime volume not specified in configuration. Please specify a volume')
+
+        self.pump_group.pump(-volume)
+
+
 

--- a/science_jubilee/tools/PumpDispenser.py
+++ b/science_jubilee/tools/PumpDispenser.py
@@ -10,19 +10,41 @@ from science_jubilee import utils
 class PumpDispenser(Tool):
     """
     Class to manage dispenser tool, for example for a color mixing demo
+    
+    :param index: The tool index of the dispenser head on the machine
+    :type indes: int
+    :param name: The tool name
+    :type name: str
+    :param pump_group: science_jubilee.tools.PeristalticPump.PeristalticPumps object to assign to dispenser head
+    :type pump_group: science_jubilee.tools.PeristalticPump.PeristalticPumps
+    :param dispense_tip_offset: Offsets from tool reference point for every dispense tip on the tool
+    :type dispense_tip_offset: list 
+    :param line_volume: Volume in mL of tubing line between pump and dispense head for 1 line
+    :type line_volume: int, float
+    :param waste: Location of waste basin
+    :type waste: class 'Well'
+
     """
 
 
     def __init__(self, index, name, pump_group, dispense_tip_offsets, line_volume, waste = None):
         """
-        parameters for user to give:
-        - number of dispenser heads (only 3 supported for now)
-        - pump:dispenser head mapping
-        - garbage/waste well
-        - line prime/purge volume
+        Dispenser tool head for use with peristaltic pumps. 
 
+        Requires science_jubilee.tools.PeristalticPump.PeristalticPumps object to control pumps
 
-        This needs to have all the well management tooling of the pipette
+        :param index: The tool index of the dispenser head on the machine
+        :type indes: int
+        :param name: The tool name
+        :type name: str
+        :param pump_group: science_jubilee.tools.PeristalticPump.PeristalticPumps object to assign to dispenser head
+        :type pump_group: science_jubilee.tools.PeristalticPump.PeristalticPumps
+        :param dispense_tip_offset: Offsets from tool reference point for every dispense tip on the tool
+        :type dispense_tip_offset: list 
+        :param line_volume: Volume in mL of tubing line between pump and dispense head for 1 line
+        :type line_volume: int, float
+        :param waste: Location of waste basin
+        :type waste: class 'Well'
         """
         super().__init__(index, name, pump_group = pump_group, dispense_tip_offsets = dispense_tip_offsets)
 
@@ -37,16 +59,12 @@ class PumpDispenser(Tool):
         
         """Initialize the pipette object from a config file
 
-        :param machine: The :class:`Machine` object that the pipette is loaded on
-        :type machine: :class:`Machine`
-        :param index: The tool index of the pipette on the machine
+        :param index: The tool index of the dispenser_head on the machine
         :type index: int
-        :param name: The tool name
-        :type name: str
-        :param config_file: The name of the config file containign the pipette parameters
+        :param config_file: The name of the config file containign the dispenser tool parameters
         :type config_file: str
-        :returns: A :class:`Pipette` object
-        :rtype: :class:`Pipette`
+        :returns: A :class:`PumpDispenser` object
+        :rtype: :class:`PumpDispenser`
         """        
         config = os.path.join(path,config_file)
         with open(config) as f:
@@ -60,7 +78,10 @@ class PumpDispenser(Tool):
 
     def add_waste(self, location: Union[Well, Tuple, Location]):
         """
-        Specify a waste collection container
+        Specify a waste collection container to dump extra liquid into. This should be large enough to catch liquid from all dispenser tips simultaneously.
+
+        :param location: location of container
+        :type location: class 'Well'
         """
         assert isinstance(location, Well) or isinstance(location, Tuple) or isinstance(location, Location), 'location must be a well, tuple, or location'
         self.waste = location
@@ -69,6 +90,13 @@ class PumpDispenser(Tool):
     def dispense(self, vol: Union[float, int, list], location:Union[Well, Tuple, Location], dispense_head_index = None):
         """
         Dispense volume vol from dispense head dispense_head_index into location 
+
+        :param vol: Volume to dispense, in mL. Specify a single number (float, int) and a dispense head index (int) to dispense from a single specific dispense head, the single volume with no dispense head to dispense this amount from all dispense tips, or a list of volumes to dispense unique amount from each dispense tip
+        :type vol: float, int list
+        :param location: Location to dispense
+        :type location: class 'Well'
+        :param dispense_head_index: index of dispense tip to dispense from, if passing single number for vol
+        :type dispense_head_index: int
         """
         # get dispense volumes for each dispense head 
         if isinstance(vol, list):
@@ -122,7 +150,12 @@ class PumpDispenser(Tool):
 
     def prime_lines(self, volume: Union[int, float] = None, location:Union[Well, Tuple, Location] = None):
         """
-        fill lines with liquid from all pumps at same time, dispense `volume` from each pump
+        Fill all lines with liquid from all pumps simultaneously.
+
+        :param volume: volume to prime with, if not specified in config file
+        :type volue: int, float
+        :param location: location of waste container, if not already specified 
+        :type location: class 'Well'
         """
 
         if volume is None:
@@ -157,7 +190,10 @@ class PumpDispenser(Tool):
         
     def empty_lines(self, volume: Union[int, float] = None):
         """
-        return line contents to stock wells
+        return line contents to stock wells. 
+
+        :param volume: line volume to return, if not set in instance already
+        :type volume: int, float 
         """
         if volume is None:
             try:

--- a/science_jubilee/tools/PumpDispenser.py
+++ b/science_jubilee/tools/PumpDispenser.py
@@ -12,6 +12,9 @@ class PumpDispenser(Tool):
     """
 
     def init()
+        
+        # offsets live in config file, pipette tip '0' is centered in Jubilee duet-level setup
+        
 
     """
     parameters for user to give:

--- a/science_jubilee/tools/PumpDispenser.py
+++ b/science_jubilee/tools/PumpDispenser.py
@@ -1,0 +1,39 @@
+import json
+import logging
+import os
+
+from science_jubilee.labware.Labware import Labware, Well, Location
+from science_jubilee.tools.Tool import Tool, ToolStateError, ToolConfigurationError, requires_active_tool
+from typing import Tuple, Union
+
+class PumpDispenser(Tool):
+    """
+    Class to manage dispenser tool, for example for a color mixing demo
+    """
+
+    def init()
+
+    """
+    parameters for user to give:
+    - number of dispenser heads (only 3 supported for now)
+    - pump:dispenser head mapping
+    - garbage/waste well
+    - line prime/purge volume
+
+
+    This needs to have all the well management tooling of the pipette
+    """
+
+    def dispense(well, volume, speed, dispense head):
+
+
+    def prime_lines(volume):
+        """
+        fill lines with liquid from all pumps at same time, dispense `volume` from each pump
+        """
+
+    def empty_lines(volume):
+        """
+        return line contents to stock wells
+        """
+

--- a/science_jubilee/tools/configs/PeristalticPumps_config.json
+++ b/science_jubilee/tools/configs/PeristalticPumps_config.json
@@ -1,0 +1,5 @@
+{
+    "name": "generic_pump",
+    "user_calibrated": false,
+    "steps_per_mL": 11500
+}

--- a/science_jubilee/tools/configs/PeristalticPumps_config.json
+++ b/science_jubilee/tools/configs/PeristalticPumps_config.json
@@ -2,6 +2,6 @@
     "name": "generic_pump",
     "steps_per_ml": 11500,
     "n_pumps": 3,
-    "index": 2,
+    "index": 200,
     "tool_axis": "E"
 }

--- a/science_jubilee/tools/configs/PeristalticPumps_config.json
+++ b/science_jubilee/tools/configs/PeristalticPumps_config.json
@@ -1,5 +1,7 @@
 {
     "name": "generic_pump",
-    "user_calibrated": false,
-    "steps_per_mL": 11500
+    "steps_per_ml": 11500,
+    "n_pumps": 3,
+    "index": 2,
+    "tool_axis": "E"
 }

--- a/science_jubilee/tools/configs/PumpDispenser_config.json
+++ b/science_jubilee/tools/configs/PumpDispenser_config.json
@@ -1,0 +1,6 @@
+{
+    "number_dispensers":3,
+    "dispense_tip_offsets":[[0,0], [10, -17.4], [-10, -17.4]],
+    "prime_line_volume": 3
+
+}

--- a/science_jubilee/tools/configs/PumpDispenser_config.json
+++ b/science_jubilee/tools/configs/PumpDispenser_config.json
@@ -1,6 +1,5 @@
 {
-    "number_dispensers":3,
+    "name": "dispenser_head",
     "dispense_tip_offsets":[[0,0], [10, -17.4], [-10, -17.4]],
-    "prime_line_volume": 3
-
+    "line_volume": 3
 }

--- a/science_jubilee/utils.py
+++ b/science_jubilee/utils.py
@@ -1,0 +1,24 @@
+from science_jubilee.labware.Labware import Labware, Well, Location
+from typing import Tuple, Union
+
+@staticmethod
+def getxyz(location: Union[Well, Tuple, Location]):
+    """Helper function to extract the x, y, z coordinates of a location object.
+
+    :param location: The location object to extract the coordinates from. This can either be a 
+        :class:`Well`, a :tuple: of x, y, z coordinates, or a :class:`Location` object
+    :type location: Union[Well, Tuple, Location]
+    :raises ValueError: If the location is not a :class:`Well`, a :class:`tuple`, or a :class:`Location` object
+    :return: The x, y, z coordinates of the location
+    :rtype: float, float, float
+    """
+    if type(location) == Well:
+        x, y, z = location.x, location.y, location.z
+    elif type(location) == Tuple:
+        x, y, z = location
+    elif type(location)==Location:
+        x,y,z= location._point
+    else:
+        raise ValueError("Location should be of type Well or Tuple")
+    
+    return x,y,z

--- a/science_jubilee/utils.py
+++ b/science_jubilee/utils.py
@@ -1,7 +1,6 @@
 from science_jubilee.labware.Labware import Labware, Well, Location
 from typing import Tuple, Union
 
-@staticmethod
 def getxyz(location: Union[Well, Tuple, Location]):
     """Helper function to extract the x, y, z coordinates of a location object.
 


### PR DESCRIPTION
Add tools to control peristaltic pumps/dispense heads developed for color mixing demo.

These tools should be extensible to any combination of stepper-driven peristaltic pump and toolhead dispenser tool. Currently driving the pumps requires having an active dispenser toolhead, b/c peristaltic pumps are an inherently un-homed motion axis and the only way I can find to manage this on Duet is with an 'E' axis, which requires the associated tool to be active to 'extrude'. Future nice-to-have would be to break apart pump and dispense tool functionality, so that pumps can do things not related to toolhead tools. 